### PR TITLE
perf(vector): Optimized the aggregateVectors function

### DIFF
--- a/backend/src/utils/chunking.ts
+++ b/backend/src/utils/chunking.ts
@@ -90,23 +90,27 @@ export function chunkText(
  * Per HMD v2 spec section 4.3: mean or attention-weighted pooling
  */
 export function aggregateVectors(vectors: number[][]): number[] {
-    if (vectors.length === 0) throw new Error('No vectors to aggregate')
-    if (vectors.length === 1) return vectors[0]
+    const n = vectors.length;
+    if (n === 0) throw new Error('No vectors to aggregate');
+    if (n === 1) return vectors[0].slice();
 
-    const dim = vectors[0].length
-    const result = new Array(dim).fill(0)
+    const dim = vectors[0].length;
+    const result = new Array(dim);
+    for (let i = 0; i < dim; ++i) result[i] = 0;
 
-    for (const vector of vectors) {
-        for (let i = 0; i < dim; i++) {
-            result[i] += vector[i]
+    for (let v = 0; v < n; ++v) {
+        const vec = vectors[v];
+        for (let i = 0; i < dim; ++i) {
+            result[i] += vec[i];
         }
     }
 
-    for (let i = 0; i < dim; i++) {
-        result[i] /= vectors.length
+    const reciprocal = 1 / n;
+    for (let i = 0; i < dim; ++i) {
+        result[i] *= reciprocal;
     }
 
-    return result
+    return result;
 }
 
 /**


### PR DESCRIPTION
## 📋 Description
<!-- Provide a brief description of the changes in this PR -->

## 🔄 Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Code refactoring
- [x] ⚡ Performance improvements
- [ ] 🧪 Test updates
- [ ] 🔧 Build/CI changes

## 🧪 Testing
<!-- Describe the tests you ran and/or added -->
- [x] I have tested this change locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## 🔍 Code Review Checklist
<!-- For reviewers -->
- [x] Code follows the project's coding standards
- [x] Self-review of the code has been performed
- [ ] Code is properly commented, particularly in hard-to-understand areas
- [x] Changes generate no new warnings
- [x] Any dependent changes have been merged and published

## 📋 Additional Context
I've once again stress-tested using (vibe-coded) benchmark code which compared the original and optimized function. The optimized function is 1.2x - 2.11x faster than the original.
You can find that benchmark code [here](https://gist.github.com/DKB0512/de854d87c5a7ca724fa033015b7d85fa)

```
Config (vecs x dim) Original (ms)  Optimized (ms) Speedup
------------------------------------------------------------
2 x 64              0.0048         0.0028         1.73x
10 x 128            0.0101         0.0048         2.11x
50 x 384            0.0599         0.0359         1.67x
100 x 768           0.1703         0.1393         1.22x
1000 x 64           0.1377         0.1173         1.17x
500 x 128           0.1269         0.1134         1.12x
200 x 1024          0.4314         0.3544         1.22x
500 x 1536          1.5229         1.2290         1.24x
800 x 3072          5.0410         4.4997         1.12x
5 x 4096            0.0878         0.0439         2.00x
```