### PR TITLE
perf(chunk): Optimized the combineChunk function

### DIFF
--- a/backend/src/utils/chunking.ts
+++ b/backend/src/utils/chunking.ts
@@ -113,5 +113,11 @@ export function aggregateVectors(vectors: number[][]): number[] {
  * Combines chunks back into full text (for display/context)
  */
 export function combineChunks(chunks: Chunk[]): string {
-    return chunks.map(c => c.text).join(' ')
+    const len = chunks.length;
+    if (len === 0) return '';
+    let str = chunks[0].text;
+    for (let i = 1; i < len; ++i) {
+        str += ' ' + chunks[i].text;
+    }
+    return str;
 }


### PR DESCRIPTION
## 📋 Description
<!-- Provide a brief description of the changes in this PR -->

## 🔄 Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI changes
- [x] ♻️ Code refactoring
- [x] ⚡ Performance improvements
- [ ] 🧪 Test updates
- [ ] 🔧 Build/CI changes

## 🧪 Testing
<!-- Describe the tests you ran and/or added -->
- [x] I have tested this change locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## 🔍 Code Review Checklist
<!-- For reviewers -->
- [x] Code follows the project's coding standards
- [x] Self-review of the code has been performed
- [ ] Code is properly commented, particularly in hard-to-understand areas
- [x] Changes generate no new warnings
- [x] Any dependent changes have been merged and published

## 📋 Additional Context
```.map()``` creates a new intermediate array of strings which causes extra memory allocation and garbage collection pressure. I've also compared the optimized function with ```.join()```. The optimized version with a only for loop got 2x performance improvement (for medium-large dataset)
You can find that benchmark code [here](https://gist.github.com/DKB0512/d8d1f1a62870a214b5b9af538671c35e)

```
Size    Original        Optimized       OptimizedWithJoin
0       0.0004ms        0.0001ms        0.0001ms
1       0.0018ms        0.0003ms        0.0004ms
5       0.0010ms        0.0017ms        0.0006ms
10      0.0015ms        0.0010ms        0.0013ms
50      0.0065ms        0.0032ms        0.0054ms
100     0.0176ms        0.0064ms        0.0098ms
500     0.0602ms        0.0204ms        0.0356ms
1000    0.1009ms        0.0414ms        0.0678ms
5000    0.4457ms        0.2139ms        0.3239ms
10000   0.8415ms        0.3765ms        0.5595ms
```
