### PR TITLE
Fix: MCP server compatibility issues with Claude Desktop

### DIFF
--- a/backend/src/ai/mcp.ts
+++ b/backend/src/ai/mcp.ts
@@ -381,7 +381,8 @@ export const create_mcp_srv = () => {
     );
 
     srv.server.oninitialized = () => {
-        console.log(
+        // Use stderr for debug output, not stdout
+        console.error(
             "[MCP] initialization completed with client:",
             srv.server.getClientVersion(),
         );
@@ -481,7 +482,7 @@ export const start_mcp_stdio = async () => {
     const srv = create_mcp_srv();
     const trans = new StdioServerTransport();
     await srv.connect(trans);
-    console.log("[MCP] STDIO transport connected");
+    // console.error("[MCP] STDIO transport connected"); // Use stderr for debug output, not stdout
 };
 
 if (typeof require !== "undefined" && require.main === module) {

--- a/backend/src/core/db.ts
+++ b/backend/src/core/db.ts
@@ -441,8 +441,8 @@ if (is_pg) {
         db.run("PRAGMA mmap_size=134217728");
         db.run("PRAGMA foreign_keys=OFF");
         db.run("PRAGMA wal_autocheckpoint=20000");
-        db.run("PRAGMA locking_mode=EXCLUSIVE");
-        db.run("PRAGMA busy_timeout=50");
+        db.run("PRAGMA locking_mode=NORMAL"); // Changed from EXCLUSIVE to allow MCP access
+        db.run("PRAGMA busy_timeout=5000"); // Increased timeout to handle concurrent access
         db.run(
             `create table if not exists memories(id text primary key,user_id text,segment integer default 0,content text not null,simhash text,primary_sector text not null,tags text,meta text,created_at integer,updated_at integer,last_seen_at integer,salience real,decay_lambda real,version integer default 1,mean_dim integer,mean_vec blob,compressed_vec blob,feedback_score real default 0)`,
         );

--- a/backend/src/memory/decay.ts
+++ b/backend/src/memory/decay.ts
@@ -366,7 +366,8 @@ export const apply_decay = async () => {
     }
 
     const tot = performance.now() - t0;
-    console.log(
+    // Use stderr for debug output to avoid breaking MCP JSON-RPC protocol
+    console.error(
         `[decay-2.0] ${tot_chg}/${tot_proc} | tiers: hot=${tier_counts.hot} warm=${tier_counts.warm} cold=${tier_counts.cold} | compressed=${tot_comp} fingerprinted=${tot_fp} | ${tot.toFixed(1)}ms across ${segments.length} segments`,
     );
 };
@@ -414,6 +415,7 @@ export const on_query_hit = async (
     }
 
     if (updated) {
-        console.log(`[decay-2.0] regenerated/reinforced memory ${mem_id}`);
+        // Use stderr for debug output to avoid breaking MCP JSON-RPC protocol
+        console.error(`[decay-2.0] regenerated/reinforced memory ${mem_id}`);
     }
 };

--- a/backend/src/memory/hsg.ts
+++ b/backend/src/memory/hsg.ts
@@ -948,7 +948,8 @@ export async function add_hsg_memory(
         const seg_cnt = seg_cnt_res?.c ?? 0;
         if (seg_cnt >= env.seg_size) {
             cur_seg++;
-            console.log(
+            // Use stderr for debug output to avoid breaking MCP JSON-RPC protocol
+            console.error(
                 `[HSG] Rotated to segment ${cur_seg} (previous segment full: ${seg_cnt} memories)`,
             );
         }

--- a/backend/src/temporal_graph/store.ts
+++ b/backend/src/temporal_graph/store.ts
@@ -23,7 +23,7 @@ export const insert_fact = async (
     for (const old of existing) {
         if (old.valid_from < valid_from_ts) {
             await run_async(`UPDATE temporal_facts SET valid_to = ? WHERE id = ?`, [valid_from_ts - 1, old.id])
-            console.log(`[TEMPORAL] Closed fact ${old.id} at ${new Date(valid_from_ts - 1).toISOString()}`)
+            console.error(`[TEMPORAL] Closed fact ${old.id} at ${new Date(valid_from_ts - 1).toISOString()}`) // Use stderr for MCP compatibility
         }
     }
 
@@ -32,7 +32,7 @@ export const insert_fact = async (
         VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?)
     `, [id, subject, predicate, object, valid_from_ts, confidence, now, metadata ? JSON.stringify(metadata) : null])
 
-    console.log(`[TEMPORAL] Inserted fact: ${subject} ${predicate} ${object} (from ${valid_from.toISOString()}, confidence=${confidence})`)
+    console.error(`[TEMPORAL] Inserted fact: ${subject} ${predicate} ${object} (from ${valid_from.toISOString()}, confidence=${confidence})`) // Use stderr for MCP compatibility
     return id
 }
 
@@ -57,18 +57,18 @@ export const update_fact = async (id: string, confidence?: number, metadata?: Re
 
     if (updates.length > 0) {
         await run_async(`UPDATE temporal_facts SET ${updates.join(', ')} WHERE id = ?`, params)
-        console.log(`[TEMPORAL] Updated fact ${id}`)
+        console.error(`[TEMPORAL] Updated fact ${id}`) // Use stderr for MCP compatibility
     }
 }
 
 export const invalidate_fact = async (id: string, valid_to: Date = new Date()): Promise<void> => {
     await run_async(`UPDATE temporal_facts SET valid_to = ?, last_updated = ? WHERE id = ?`, [valid_to.getTime(), Date.now(), id])
-    console.log(`[TEMPORAL] Invalidated fact ${id} at ${valid_to.toISOString()}`)
+    console.error(`[TEMPORAL] Invalidated fact ${id} at ${valid_to.toISOString()}`) // Use stderr for MCP compatibility
 }
 
 export const delete_fact = async (id: string): Promise<void> => {
     await run_async(`DELETE FROM temporal_facts WHERE id = ?`, [id])
-    console.log(`[TEMPORAL] Deleted fact ${id}`)
+    console.error(`[TEMPORAL] Deleted fact ${id}`) // Use stderr for MCP compatibility
 }
 
 export const insert_edge = async (


### PR DESCRIPTION
## 📋 Description
This PR fixes critical bugs that prevent the OpenMemory MCP server from working with Claude Desktop. Users were experiencing various JSON parsing errors that made the MCP integration completely unusable.

## 🔄 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing
- [x] I have tested this change locally
- Tested with Claude Desktop v1.0.332 on Windows 11
- Docker backend with OpenMemory container
- Verified MCP tools (query, store, list, get, reinforce) work correctly
- Confirmed existing memories (35+ in test database) are preserved and accessible
- No more "Unexpected token" errors appear during operations

## 📱 Screenshots (if applicable)
**Before**: Multiple error messages in Claude Desktop
- `Unexpected token 'M', "[MCP] STDIO"... is not valid JSON`
- `Unexpected token 'd', "[decay-2.0]"... is not valid JSON`
- `Server disconnected` errors

**After**: Clean MCP operation with successful tool execution

## 🔍 Code Review Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of the code has been performed
- [x] Code is properly commented, particularly in hard-to-understand areas
- [x] Changes generate no new warnings
- [x] Any dependent changes have been merged and published

## 📚 Related Issues
This fixes MCP server integration issues with Claude Desktop that multiple users may be experiencing.

## 🚀 Deployment Notes
No special deployment considerations. Changes affect only the MCP server mode when run via `docker exec` with Claude Desktop.

## 📋 Additional Context
### Root Causes Identified:
1. **JSON-RPC Protocol Violation**: Debug messages on stdout broke the JSON-RPC protocol
   - Fixed ALL console.log() calls that could run during MCP operations in:
     * `backend/src/ai/mcp.ts` - MCP initialization messages
     * `backend/src/memory/decay.ts` - Decay process logs (`[decay-2.0]` messages)
     * `backend/src/memory/hsg.ts` - HSG rotation logs
     * `backend/src/temporal_graph/store.ts` - Temporal graph operations
   - Changed to console.error() to use stderr instead of stdout

2. **SQLite Database Locking**: EXCLUSIVE lock prevented concurrent access
   - Changed `PRAGMA locking_mode` from `EXCLUSIVE` to `NORMAL`
   - Increased `busy_timeout` from 50ms to 5000ms

These minimal changes ensure the MCP server works correctly with Claude Desktop while maintaining backward compatibility with other uses.