### PR TITLE
feat(scoring): increase tag_match weight for better explicit signal handling

### DIFF
--- a/backend/src/memory/hsg.ts
+++ b/backend/src/memory/hsg.ts
@@ -107,11 +107,11 @@ export const sector_configs: Record<string, sector_cfg> = {
 };
 export const sectors = Object.keys(sector_configs);
 export const scoring_weights = {
-    similarity: 0.40,
+    similarity: 0.35,
     overlap: 0.20,
     waypoint: 0.15,
-    recency: 0.15,
-    tag_match: 0.10,
+    recency: 0.10,
+    tag_match: 0.20,
 };
 export const hybrid_params = {
     tau: 3,


### PR DESCRIPTION
## Summary
- Increase tag_match weight from 0.10 to 0.20 (doubled)
- Reduce similarity weight from 0.40 to 0.35
- Reduce recency weight from 0.15 to 0.10
- Total weights still sum to 1.00

## Problem
Tags are explicit user signals about memory relevance, but they only contributed 10% to the final retrieval score. This meant that even perfect tag matches were easily overwhelmed by slightly higher vector similarity from unrelated content.

For example, a memory tagged with `matching-algorithm` would not rank higher when searching for "matching algorithm" if other memories had slightly better vector similarity but no relevant tags.

## Rationale
Tags represent deliberate user categorization and should have meaningful impact on retrieval ranking. The rebalancing:
- Takes a small amount from similarity (still dominant at 35%)
- Takes a small amount from recency (which can over-prioritize recent but less relevant memories)
- Doubles the impact of explicit tag signals

## Weight Changes
| Weight | Before | After | Change |
|--------|--------|-------|--------|
| similarity | 0.40 | 0.35 | -0.05 |
| overlap | 0.20 | 0.20 | - |
| waypoint | 0.15 | 0.15 | - |
| recency | 0.15 | 0.10 | -0.05 |
| tag_match | 0.10 | 0.20 | +0.10 |

## Test Plan
- [ ] Verify memories with matching tags rank higher than before
- [ ] Verify overall retrieval quality is not degraded
- [ ] Verify tag-heavy queries benefit from the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)