### PR TITLE
feat: batch sector embeddings for faster queries

### DIFF
--- a/backend/src/memory/hsg.ts
+++ b/backend/src/memory/hsg.ts
@@ -645,6 +645,7 @@ export async function prune_weak_waypoints(): Promise<number> {
 }
 import {
     embedForSector,
+    embedQueryForAllSectors,
     embedMultiSector,
     cosineSimilarity,
     bufferToVector,
@@ -778,8 +779,8 @@ export async function hsg_query(
             ss = [...sectors];
         }
         if (!ss.length) ss.push("semantic");
-        const qe: Record<string, number[]> = {};
-        for (const s of ss) qe[s] = await embedForSector(qt, s);
+        // Batch embed all sectors in one API call for faster queries
+        const qe = await embedQueryForAllSectors(qt, ss);
         const w: multi_vec_fusion_weights = {
             semantic_dimension_weight: qc.primary === "semantic" ? 1.2 : 0.8,
             emotional_dimension_weight: qc.primary === "emotional" ? 1.5 : 0.6,


### PR DESCRIPTION
## Summary
- Reduces query time by **~4.5x** (10s → 2.1s) by batching all 5 sector embeddings into a single Gemini API call
- Adds `embedQueryForAllSectors()` function that leverages existing `batchEmbedContents` endpoint
- Falls back gracefully to sequential embedding if batch fails

## Performance Results
| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Embedding time | ~3750ms (5 calls) | ~315ms (1 call) | **12x faster** |
| Total query time | ~10 seconds | ~2.1 seconds | **4.5x faster** |

## Changes
- `backend/src/memory/embed.ts`: Add `embedQueryForAllSectors()` function
- `backend/src/memory/hsg.ts`: Update `hsg_query()` to use batch embedding

## Test plan
- [x] Verified build passes
- [x] Tested 3 consecutive queries: 2168ms, 2172ms, 2144ms (consistent)
- [x] Verified logs show: `[EMBED] Batched 5 sectors in one Gemini call`
- [ ] Test with different OM_TIER settings (hybrid/fast use synthetic, already fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)