### PR TITLE
fix: Memory Query Load chart timeline ordering and period selection

### DIFF
--- a/backend/src/server/routes/dashboard.ts
+++ b/backend/src/server/routes/dashboard.ts
@@ -296,12 +296,14 @@ export function dash(app: any) {
                 displayFormat = is_pg
                     ? "to_char(to_timestamp(created_at/1000), 'MM-DD')"
                     : "strftime('%m-%d', datetime(created_at/1000, 'unixepoch', 'localtime'))";
-                sortFormat = displayFormat;
+                sortFormat = is_pg
+                    ? "to_char(to_timestamp(created_at/1000), 'YYYY-MM-DD')"
+                    : "strftime('%Y-%m-%d', datetime(created_at/1000, 'unixepoch', 'localtime'))";
                 timeKey = "day";
             } else {
-                // For longer periods, group by week
+                // For longer periods, group by week (ISO week format for consistency)
                 displayFormat = is_pg
-                    ? "to_char(to_timestamp(created_at/1000), 'YYYY-WW')"
+                    ? "to_char(to_timestamp(created_at/1000), 'IYYY-\"W\"IW')"
                     : "strftime('%Y-W%W', datetime(created_at/1000, 'unixepoch', 'localtime'))";
                 sortFormat = displayFormat;
                 timeKey = "week";
@@ -309,14 +311,14 @@ export function dash(app: any) {
 
             const tl = await all_async(
                 is_pg
-                    ? `SELECT primary_sector, ${displayFormat} as period, ${sortFormat} as sort_key, COUNT(*) as count
-                       FROM ${mem_table} WHERE created_at > $1 GROUP BY primary_sector, sort_key ORDER BY sort_key`
-                    : `SELECT primary_sector, ${displayFormat} as period, ${sortFormat} as sort_key, COUNT(*) as count
-                       FROM ${mem_table} WHERE created_at > ? GROUP BY primary_sector, sort_key ORDER BY sort_key`,
+                    ? `SELECT primary_sector, ${displayFormat} as label, ${sortFormat} as sort_key, COUNT(*) as count
+                       FROM ${mem_table} WHERE created_at > $1 GROUP BY primary_sector, ${sortFormat} ORDER BY sort_key`
+                    : `SELECT primary_sector, ${displayFormat} as label, ${sortFormat} as sort_key, COUNT(*) as count
+                       FROM ${mem_table} WHERE created_at > ? GROUP BY primary_sector, ${sortFormat} ORDER BY sort_key`,
                 [strt],
             );
             res.json({
-                timeline: tl.map((row: any) => ({ ...row, hour: row.period })),
+                timeline: tl.map((row: any) => ({ ...row, hour: row.label })),
                 grouping: timeKey,
             });
         } catch (e: any) {

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -117,14 +117,17 @@ export default function Dashboard() {
                     grouped[key][item.primary_sector] = item.count
                 })
 
-                const chartData = Object.values(grouped).map((item: any) => ({
-                    hour: item.hour,
-                    semantic: item.semantic || 0,
-                    episodic: item.episodic || 0,
-                    procedural: item.procedural || 0,
-                    emotional: item.emotional || 0,
-                    reflective: item.reflective || 0,
-                }))
+                // Explicitly sort by sort_key for proper chronological ordering
+                const chartData = Object.values(grouped)
+                    .sort((a: any, b: any) => (a.sort_key || a.hour).localeCompare(b.sort_key || b.hour))
+                    .map((item: any) => ({
+                        hour: item.hour,
+                        semantic: item.semantic || 0,
+                        episodic: item.episodic || 0,
+                        procedural: item.procedural || 0,
+                        emotional: item.emotional || 0,
+                        reflective: item.reflective || 0,
+                    }))
 
                 setQpsData(chartData)
             }


### PR DESCRIPTION
## Summary
- Fixes the Memory Query Load chart that was incorrectly grouping data from different days into the same hour bars
- Makes the period dropdown (24h, 7d, 30d) actually functional

## Problem
The timeline chart was grouping memories only by hour (e.g., "14:00") without considering the date, causing data from multiple days to be merged into the same bars. Additionally, the period selector dropdown was not connected to any state.

## Solution
- **Backend**: Added a `sort_key` field with full date+hour for proper chronological ordering while displaying only the hour
- **Backend**: Dynamic grouping based on period (hour for 24h, day for 7d, week for 30d+)
- **Backend**: Support for both PostgreSQL and SQLite date formatting
- **Frontend**: Connected dropdown to state and API calls
- **Frontend**: Use `sort_key` for grouping to distinguish same hours on different days

## Testing
- Verified chart shows separate bars for same hour on different days
- Verified period dropdown changes the data displayed
- Tested with SQLite backend