### PR TITLE
fix: improve timezone support and 30-day chart format

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -38,6 +38,9 @@ FROM node:20-alpine AS production
 
 WORKDIR /app
 
+# Install timezone data for proper TZ support
+RUN apk add --no-cache tzdata
+
 # Create a dedicated non-root user for security
 RUN addgroup -g 1001 -S appgroup \
  && adduser -u 1001 -S appuser -G appgroup

--- a/backend/src/server/routes/dashboard.ts
+++ b/backend/src/server/routes/dashboard.ts
@@ -301,12 +301,14 @@ export function dash(app: any) {
                     : "strftime('%Y-%m-%d', datetime(created_at/1000, 'unixepoch', 'localtime'))";
                 timeKey = "day";
             } else {
-                // For longer periods, group by week (ISO week format for consistency)
+                // For longer periods (30 days), group by day showing month-day
                 displayFormat = is_pg
-                    ? "to_char(to_timestamp(created_at/1000), 'IYYY-\"W\"IW')"
-                    : "strftime('%Y-W%W', datetime(created_at/1000, 'unixepoch', 'localtime'))";
-                sortFormat = displayFormat;
-                timeKey = "week";
+                    ? "to_char(to_timestamp(created_at/1000), 'MM-DD')"
+                    : "strftime('%m-%d', datetime(created_at/1000, 'unixepoch', 'localtime'))";
+                sortFormat = is_pg
+                    ? "to_char(to_timestamp(created_at/1000), 'YYYY-MM-DD')"
+                    : "strftime('%Y-%m-%d', datetime(created_at/1000, 'unixepoch', 'localtime'))";
+                timeKey = "day";
             }
 
             const tl = await all_async(


### PR DESCRIPTION
## Summary
Follow-up to #79 - Improves the dashboard timeline chart with two fixes:

- **Timezone support**: Adds `tzdata` package to Docker image so the `TZ` environment variable works correctly in Alpine Linux. This allows users to set their local timezone (e.g., `TZ=America/Santiago`) and have charts display times in their local timezone instead of UTC.

- **30-day format**: Changes the 30-day timeline view from week numbers (`2025-W48`) to day/month format (`12-02`) for better readability.

## Changes
- `backend/Dockerfile`: Add `tzdata` package installation
- `backend/src/server/routes/dashboard.ts`: Update long-period grouping to use day/month format

## Testing
- Verified timezone displays correctly when `TZ` is set in docker-compose
- Verified 24h view shows correct local hour
- Verified 30d view shows `MM-DD` format instead of week numbers