### PR TITLE
fix(dashboard): handle undefined vectors in cosineSimilarity

### DIFF
--- a/dashboard/lib/memory-ai-engine.ts
+++ b/dashboard/lib/memory-ai-engine.ts
@@ -327,7 +327,7 @@ class TextProcessor {
      * Calculate cosine similarity between two vectors
      */
     static cosineSimilarity(a: number[], b: number[]): number {
-        if (a.length !== b.length) return 0
+        if (!a || !b || a.length !== b.length) return 0
         let dot = 0, magA = 0, magB = 0
         for (let i = 0; i < a.length; i++) {
             dot += a[i] * b[i]
@@ -893,7 +893,7 @@ class MemoryClusterer {
                 if (assigned.has(j)) continue
 
                 const avgDist = vectors
-                    .map((v, k) => assigned.has(k) ? 0 : TextProcessor.cosineSimilarity(vectors[j], v))
+                    .map((v, k) => assigned.has(k) || !vectors[j] || !v ? 0 : TextProcessor.cosineSimilarity(vectors[j], v))
                     .reduce((a, b) => a + b, 0) / Math.max(1, memories.length - assigned.size)
 
                 if (avgDist > maxAvgDist) {
@@ -909,7 +909,7 @@ class MemoryClusterer {
 
             const similarities = vectors.map((v, idx) => ({
                 idx,
-                sim: TextProcessor.cosineSimilarity(vectors[seedIdx], v)
+                sim: !vectors[seedIdx] || !v ? 0 : TextProcessor.cosineSimilarity(vectors[seedIdx], v)
             }))
                 .filter(s => !assigned.has(s.idx))
                 .sort((a, b) => b.sim - a.sim)


### PR DESCRIPTION
## Summary

Fixes the Dashboard AI Chat crash caused by undefined vectors passed to `cosineSimilarity()`.

Fixes #82

## Changes

- Added null check in `TextProcessor.cosineSimilarity()` before accessing `.length`
- Added defensive guard in `MemoryClusterer.cluster()` before similarity calculations

## Root Cause

The `computeTfIdf()` function stores vectors in a Map keyed by document content. When memory content is empty or duplicated, this can result in undefined entries when iterating vectors by index.

## Testing

- Verified fix locally with 1,000+ memories
- Chat queries now succeed without TypeError
- Response generation completes successfully

## Additional Observation

While testing the fix, we noticed that after the crash is resolved, the Chat with Memories feature generates responses that may not be semantically relevant to the user's query. For example, asking "What are the largest memories I have?" returned documentation about MCP usage rather than memory size information. This appears to be a separate issue with the retrieval/synthesis logic and is outside the scope of this fix, but we wanted to flag it for the maintainers' awareness.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)