### PR TITLE
fix(api): handle null request body in DELETE /memory/:id

### DIFF
--- a/backend/src/server/routes/memory.ts
+++ b/backend/src/server/routes/memory.ts
@@ -213,7 +213,7 @@ export function mem(app: any) {
     app.delete("/memory/:id", async (req: any, res: any) => {
         try {
             const id = req.params.id;
-            const user_id = req.query.user_id || req.body.user_id;
+            const user_id = req.query.user_id || req.body?.user_id;
             const m = await q.get_mem.get(id);
             if (!m) return res.status(404).json({ err: "nf" });
 


### PR DESCRIPTION
# fix(api): handle null request body in DELETE /memory/:id

## 📋 Description

The DELETE `/memory/:id` endpoint crashes with a 500 Internal Server Error when called without a request body.

**Root cause:** The endpoint accesses `req.body.user_id` to check for optional user ownership validation. However, when a DELETE request has no body, `req.body` is `null` (not an empty object). Accessing `null.user_id` throws:

```
TypeError: Cannot read properties of null (reading 'user_id')
```

**How it was found:** This bug was discovered when trying to delete memories from the OpenMemory dashboard. The dashboard's delete button sends a DELETE request without a body, which triggers the crash. The dashboard shows a generic error, but inspecting the network request reveals a 500 response with `{"err":"internal"}`.

**Fix:** Use optional chaining (`req.body?.user_id`) to safely handle the case when `req.body` is null.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvements
- [ ] 🧪 Test updates
- [ ] 🔧 Build/CI changes

## 🧪 Testing

- [x] I have tested this change locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

**Manual testing performed:**

Before fix:
```bash
$ curl -X DELETE "http://localhost:8787/memory/<id>"
{"err":"internal"}
```

After fix:
```bash
$ curl -X DELETE "http://localhost:8787/memory/<id>"
{"ok":true}
```

## 📱 Screenshots (if applicable)

N/A - API-only change.

## 🔍 Code Review Checklist

- [x] Code follows the project's coding standards
- [x] Self-review of the code has been performed
- [x] Code is properly commented, particularly in hard-to-understand areas
- [x] Changes generate no new warnings
- [x] Any dependent changes have been merged and published

## 📚 Related Issues

None found in the issue tracker, but this affects all dashboard users attempting to delete memories.

## 🚀 Deployment Notes

No special deployment considerations. This is a one-line fix with no breaking changes.

## 📋 Additional Context

The change is minimal and safe:

```diff
- const user_id = req.query.user_id || req.body.user_id;
+ const user_id = req.query.user_id || req.body?.user_id;
```

The `user_id` parameter is optional and used only for ownership validation when provided. The fix ensures that:
1. If `req.body` is null → `user_id` becomes `undefined` → ownership check is skipped (existing behavior when no user_id provided)
2. If `req.body` exists → behavior is unchanged

