### PR TITLE
chore(sdk-js): bump version to 1.0.2

### DIFF
--- a/sdk-js/package-lock.json
+++ b/sdk-js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openmemory-js",
-    "version": "0.2.0",
+    "version": "1.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "openmemory-js",
-            "version": "0.2.0",
+            "version": "1.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/client-bedrock-runtime": "^3.450.0",

--- a/sdk-js/package.json
+++ b/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openmemory-js",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Local-first long-term memory engine for AI apps and agents. Provides semantic search, multi-sector memory, temporal facts, decay, and full explainability. Works standalone or with the OpenMemory backend.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixes CI breaking 
```
npm error 403 403 Forbidden - PUT https://registry.npmjs.org/openmemory-js - You cannot publish over the previously published versions: 1.0.1.
```