### PR TITLE
fix(mcp): resolve STDIO protocol violations and PostgreSQL parameter bugs

### DIFF
--- a/packages/openmemory-js/src/core/models.ts
+++ b/packages/openmemory-js/src/core/models.ts
@@ -9,13 +9,13 @@ export const load_models = (): model_cfg => {
     if (cfg) return cfg;
     const p = join(__dirname, "../../../models.yml");
     if (!existsSync(p)) {
-        console.warn("[MODELS] models.yml not found, using defaults");
+        console.error("[MODELS] models.yml not found, using defaults");
         return get_defaults();
     }
     try {
         const yml = readFileSync(p, "utf-8");
         cfg = parse_yaml(yml);
-        console.log(
+        console.error(
             `[MODELS] Loaded models.yml (${Object.keys(cfg).length} sectors)`,
         );
         return cfg;

--- a/packages/openmemory-js/src/core/vector/postgres.ts
+++ b/packages/openmemory-js/src/core/vector/postgres.ts
@@ -15,7 +15,7 @@ export class PostgresVectorStore implements VectorStore {
     }
 
     async storeVector(id: string, sector: string, vector: number[], dim: number, user_id?: string): Promise<void> {
-        console.log(`[Vector] Storing ID: ${id}, Sector: ${sector}, Dim: ${dim}`);
+        console.error(`[Vector] Storing ID: ${id}, Sector: ${sector}, Dim: ${dim}`);
         const v = vectorToBuffer(vector);
         const sql = `insert into ${this.table}(id,sector,user_id,v,dim) values($1,$2,$3,$4,$5) on conflict(id,sector) do update set user_id=excluded.user_id,v=excluded.v,dim=excluded.dim`;
         await this.db.run_async(sql, [id, sector, user_id || "anonymous", v, dim]);
@@ -32,7 +32,7 @@ export class PostgresVectorStore implements VectorStore {
     async searchSimilar(sector: string, queryVec: number[], topK: number): Promise<Array<{ id: string; score: number }>> {
         // Postgres implementation (in-memory cosine sim for now, as per original)
         const rows = await this.db.all_async(`select id,v,dim from ${this.table} where sector=$1`, [sector]);
-        console.log(`[Vector] Search Sector: ${sector}, Found ${rows.length} rows.`);
+        console.error(`[Vector] Search Sector: ${sector}, Found ${rows.length} rows.`);
         const sims: Array<{ id: string; score: number }> = [];
         for (const row of rows) {
             const vec = bufferToVector(row.v);

--- a/packages/openmemory-js/src/memory/reflect.ts
+++ b/packages/openmemory-js/src/memory/reflect.ts
@@ -102,18 +102,18 @@ const boost = async (ids: string[]) => {
 };
 
 export const run_reflection = async () => {
-    console.log("[REFLECT] Starting reflection job...");
+    console.error("[REFLECT] Starting reflection job...");
     const min = env.reflect_min || 20;
     const mems = await q.all_mem.all(100, 0);
-    console.log(
+    console.error(
         `[REFLECT] Fetched ${mems.length} memories (min required: ${min})`,
     );
     if (mems.length < min) {
-        console.log("[REFLECT] Not enough memories, skipping");
+        console.error("[REFLECT] Not enough memories, skipping");
         return { created: 0, reason: "low" };
     }
     const cls = cluster(mems);
-    console.log(`[REFLECT] Clustered into ${cls.length} groups`);
+    console.error(`[REFLECT] Clustered into ${cls.length} groups`);
     let n = 0;
     for (const c of cls) {
         const txt = summ(c);
@@ -125,7 +125,7 @@ export const run_reflection = async () => {
             freq: c.n,
             at: new Date().toISOString(),
         };
-        console.log(
+        console.error(
             `[REFLECT] Creating reflection: ${c.n} memories, salience=${s.toFixed(3)}, sector=${c.mem[0].primary_sector}`,
         );
         await add_hsg_memory(txt, j(["reflect:auto"]), meta);
@@ -134,7 +134,7 @@ export const run_reflection = async () => {
         n++;
     }
     if (n > 0) await log_maint_op("reflect", n);
-    console.log(`[REFLECT] Job complete: created ${n} reflections`);
+    console.error(`[REFLECT] Job complete: created ${n} reflections`);
     return { created: n, clusters: cls.length };
 };
 
@@ -147,7 +147,7 @@ export const start_reflection = () => {
         () => run_reflection().catch((e) => console.error("[REFLECT]", e)),
         int,
     );
-    console.log(`[REFLECT] Started: every ${env.reflect_interval || 10}m`);
+    console.error(`[REFLECT] Started: every ${env.reflect_interval || 10}m`);
 };
 
 export const stop_reflection = () => {


### PR DESCRIPTION
## Problem
OpenMemory fails when used via MCP STDIO transport and with PostgreSQL backends due to:
1. Console logging to stdout breaking JSON-RPC protocol
2. AWS Bedrock embedding response parsing error
3. Database parameter order causing UUID/bigint type mismatches

## Changes

### MCP STDIO Protocol Fixes
Changed stdout logging to stderr in:
- `embed.ts`: 10 console.log/warn → console.error
- `models.ts`: 2 console.warn/log → console.error
- `db.ts`: 4 console.log → console.error
- `postgres.ts`: 2 console.log → console.error
- `reflect.ts`: 4 console.log → console.error

### AWS Bedrock Fix
- `embed.ts` line 389: Access `parsedResponse.embedding` instead of `parsedResponse`

### PostgreSQL Parameter Order Fixes
- `hsg.ts`: Fixed 5 `upd_seen.run()` calls
- `hsg.ts`: Fixed 2 `upd_waypoint.run()` calls

## Testing
- ✅ Built successfully with `npm run build`
- ✅ Tested with PostgreSQL backend
- ✅ Tested with AWS Bedrock embeddings
- ✅ Verified MCP STDIO transport stability

## Checklist
- [x] Code follows conventional commits format
- [x] Changes are backwards compatible
- [x] No API changes
- [x] Code builds successfully
