### PR TITLE
feat(mcp): add temporal graph support to MCP tools

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,605 @@
+# MCP Server Reference
+
+OpenMemory provides a Model Context Protocol (MCP) server that exposes memory operations as tools for AI assistants like Claude, Cursor, and Windsurf.
+
+## Setup
+
+### Installation
+
+```bash
+# Use via npx (no installation needed)
+npx -y openmemory-js mcp
+
+# Or install globally
+npm install -g openmemory-js
+openmemory-js mcp
+```
+
+### Configuration
+
+Configure your MCP client (`.mcp.json` for Cursor/Windsurf, or Claude settings):
+
+```json
+{
+  "mcpServers": {
+    "openmemory": {
+      "command": "npx",
+      "args": ["-y", "openmemory-js", "mcp"],
+      "env": {
+        "OM_METADATA_BACKEND": "sqlite",
+        "OM_EMBEDDINGS": "openai",
+        "OPENAI_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+#### Environment Variables
+
+- `OM_METADATA_BACKEND`: Database type (`sqlite` or `postgres`)
+- `OM_EMBEDDINGS`: Embedding provider (`openai`, `aws`, `ollama`, `synthetic`)
+- Database credentials (if using Postgres): `OM_PG_HOST`, `OM_PG_DB`, `OM_PG_USER`, `OM_PG_PASSWORD`
+
+## Memory Systems
+
+OpenMemory provides two complementary memory systems:
+
+### Contextual Memory (HSG)
+Semantic memory organized into cognitive sectors (episodic, semantic, procedural, emotional, reflective) with vector-based retrieval.
+
+**Best for:** Conversations, rich context, experiential memories
+
+### Temporal Facts
+Structured facts (subject-predicate-object triples) with time-based validity and automatic invalidation.
+
+**Best for:** Preferences, business rules, configurations that change over time
+
+## Available Tools
+
+### openmemory_store
+
+Store content in contextual memory, temporal facts, or both.
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `content` | string | Yes | - | Raw memory text |
+| `type` | enum | No | "contextual" | Storage type: "contextual", "factual", or "both" |
+| `facts` | array | Conditional | - | Facts array (required if type is "factual" or "both") |
+| `tags` | string[] | No | - | Tags for contextual storage |
+| `metadata` | object | No | - | Additional metadata |
+| `user_id` | string | No | - | User identifier |
+
+#### Facts Array Schema
+
+```typescript
+{
+  subject: string,      // Entity (e.g., "user_123", "client_acme")
+  predicate: string,    // Relationship (e.g., "prefers_format", "approval_limit")
+  object: string,       // Value (e.g., "Excel", "50000")
+  confidence?: number,  // 0-1 score (default: 1.0)
+  valid_from?: string   // ISO date (default: now)
+}
+```
+
+#### Examples
+
+**Store contextual memory:**
+```json
+{
+  "content": "User prefers morning meetings",
+  "tags": ["preference", "scheduling"],
+  "user_id": "user_123"
+}
+```
+
+**Store temporal fact:**
+```json
+{
+  "content": "Client prefers Excel format",
+  "type": "factual",
+  "facts": [{
+    "subject": "client_acme",
+    "predicate": "prefers_report_format",
+    "object": "Excel"
+  }],
+  "user_id": "user_123"
+}
+```
+
+**Store in both systems:**
+```json
+{
+  "content": "Approval threshold updated to $75K",
+  "type": "both",
+  "facts": [{
+    "subject": "expense_policy",
+    "predicate": "approval_threshold_usd",
+    "object": "75000"
+  }],
+  "tags": ["policy", "threshold"],
+  "user_id": "user_123"
+}
+```
+
+### openmemory_query
+
+Query contextual memories, temporal facts, or both.
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | Yes | - | Search text |
+| `type` | enum | No | "contextual" | Query type: "contextual", "factual", or "unified" |
+| `fact_pattern` | object | No | - | Pattern for temporal queries |
+| `at` | string | No | now | ISO date for point-in-time queries |
+| `k` | number | No | 8 | Max results for contextual queries |
+| `sector` | enum | No | - | Filter by sector (episodic, semantic, procedural, emotional, reflective) |
+| `min_salience` | number | No | - | Minimum salience threshold (0-1) |
+| `user_id` | string | No | - | User identifier |
+
+#### Fact Pattern Schema
+
+```typescript
+{
+  subject?: string,    // Entity to match (undefined = wildcard)
+  predicate?: string,  // Relationship to match (undefined = wildcard)
+  object?: string      // Value to match (undefined = wildcard)
+}
+```
+
+#### Examples
+
+**Query contextual memories:**
+```json
+{
+  "query": "user preferences",
+  "user_id": "user_123"
+}
+```
+
+**Query current facts:**
+```json
+{
+  "query": "client report format",
+  "type": "factual",
+  "fact_pattern": {
+    "subject": "client_acme",
+    "predicate": "prefers_report_format"
+  }
+}
+```
+
+**Historical query:**
+```json
+{
+  "query": "Q3 approval limit",
+  "type": "factual",
+  "fact_pattern": {
+    "subject": "expense_policy",
+    "predicate": "approval_threshold_usd"
+  },
+  "at": "2023-09-30T00:00:00Z"
+}
+```
+
+**Unified query:**
+```json
+{
+  "query": "client information",
+  "type": "unified",
+  "fact_pattern": {
+    "subject": "client_acme"
+  },
+  "k": 10,
+  "user_id": "user_123"
+}
+```
+
+### openmemory_list
+
+List recent memories.
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `limit` | number | No | 10 | Number of memories to return (max 50) |
+| `sector` | enum | No | - | Filter by sector |
+| `user_id` | string | No | - | User identifier |
+
+#### Example
+
+```json
+{
+  "limit": 20,
+  "sector": "semantic",
+  "user_id": "user_123"
+}
+```
+
+### openmemory_get
+
+Fetch a single memory by ID.
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `id` | string | Yes | - | Memory identifier |
+| `include_vectors` | boolean | No | false | Include sector vector metadata |
+| `user_id` | string | No | - | User identifier |
+
+#### Example
+
+```json
+{
+  "id": "mem_abc123",
+  "include_vectors": true,
+  "user_id": "user_123"
+}
+```
+
+### openmemory_reinforce
+
+Boost salience of a memory.
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `id` | string | Yes | - | Memory identifier |
+| `boost` | number | No | 0.1 | Salience boost amount (0.01-1.0) |
+
+#### Example
+
+```json
+{
+  "id": "mem_abc123",
+  "boost": 0.15
+}
+```
+
+## Response Formats
+
+### openmemory_store
+
+**Contextual storage:**
+```json
+{
+  "type": "contextual",
+  "hsg": {
+    "id": "mem_abc123",
+    "primary_sector": "semantic",
+    "sectors": ["semantic", "procedural"]
+  }
+}
+```
+
+**Factual storage:**
+```json
+{
+  "type": "factual",
+  "temporal": [{
+    "id": "fact_xyz789",
+    "subject": "client_acme",
+    "predicate": "prefers_format",
+    "object": "Excel",
+    "valid_from": "2024-01-15T10:00:00.000Z",
+    "confidence": 0.95
+  }]
+}
+```
+
+### openmemory_query
+
+**Contextual query:**
+```json
+{
+  "type": "contextual",
+  "contextual": [{
+    "source": "hsg",
+    "id": "mem_abc123",
+    "score": 0.8921,
+    "content": "User prefers morning meetings...",
+    "primary_sector": "semantic",
+    "salience": 0.756
+  }]
+}
+```
+
+**Factual query:**
+```json
+{
+  "type": "factual",
+  "factual": [{
+    "source": "temporal",
+    "id": "fact_xyz789",
+    "subject": "client_acme",
+    "predicate": "prefers_format",
+    "object": "Excel",
+    "confidence": 0.95,
+    "valid_from": "2024-01-15T10:00:00.000Z",
+    "valid_to": null
+  }]
+}
+```
+
+**Unified query:**
+```json
+{
+  "type": "unified",
+  "contextual": [...],  // HSG results
+  "factual": [...]      // Temporal facts
+}
+```
+
+## Key Features
+
+### Automatic Fact Invalidation
+
+When storing a fact with the same subject+predicate, the previous fact is automatically closed:
+
+```
+Day 1: Store (client_acme, prefers_format, PDF)
+       → Stored with valid_to = null
+
+Day 2: Store (client_acme, prefers_format, Excel)  
+       → Old fact: valid_to = Day 2 (closed)
+       → New fact: valid_to = null (current)
+```
+
+### Point-in-Time Queries
+
+Query what was true at any historical date:
+
+```json
+{
+  "type": "factual",
+  "fact_pattern": {"subject": "client_acme", "predicate": "prefers_format"},
+  "at": "2024-01-10T00:00:00Z"
+}
+```
+
+Returns the fact that was valid on January 10th, even if it's since been updated.
+
+### Wildcard Patterns
+
+Use undefined fields in `fact_pattern` for wildcards:
+
+```json
+// All facts about client_acme
+{"subject": "client_acme"}
+
+// All preferences for any subject
+{"predicate": "prefers"}
+
+// All facts with object "Excel"
+{"object": "Excel"}
+```
+
+## Best Practices
+
+### Storage Type Selection
+
+| Type | Use Case | Example |
+|------|----------|---------|
+| `contextual` | Rich narratives, conversations | "Team discussed the Q4 strategy..." |
+| `factual` | Structured data that changes | client_acme prefers_format Excel |
+| `both` | Rich context with extractable facts | "Client wants monthly Excel reports" |
+
+### Fact Naming Conventions
+
+**Subject:** Specific entity identifier
+- ✅ `user_123`, `client_acme_corp`, `expense_policy`
+- ❌ `the user`, `client`, `policy`
+
+**Predicate:** Clear relationship in snake_case
+- ✅ `prefers_report_format`, `requires_approval_at`, `uses_data_source`
+- ❌ `preference`, `requirement`, `uses`
+
+**Object:** Concrete value
+- ✅ `Excel`, `50000`, `Salesforce_CRM`
+- ❌ `file format`, `high`, `CRM system`
+
+### Query Strategy
+
+**Use `type="contextual"` when:**
+- Asking open-ended questions
+- Needing semantic similarity
+- Searching conversations
+
+**Use `type="factual"` when:**
+- Asking for specific current values
+- Querying structured data
+- Need historical accuracy
+
+**Use `type="unified"` when:**
+- Need comprehensive context
+- Unsure which system has the answer
+- Want both semantic context AND facts
+
+## Integration Examples
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "openmemory": {
+      "command": "npx",
+      "args": ["-y", "openmemory-js", "mcp"]
+    }
+  }
+}
+```
+
+### Cursor / Windsurf
+
+Add to `.cursorrules` or `.windsurfrules`:
+
+```
+When storing user information, use openmemory_store:
+- type="contextual" for conversations
+- type="factual" for preferences that may change
+- Always include user_id parameter
+
+When querying, use openmemory_query:
+- type="unified" for comprehensive context
+- Construct fact_pattern for specific fact queries
+```
+
+### Programmatic (Node.js)
+
+```typescript
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const client = new Client({
+  name: 'my-app',
+  version: '1.0.0'
+}, { capabilities: {} });
+
+const transport = new StdioClientTransport({
+  command: 'npx',
+  args: ['-y', 'openmemory-js', 'mcp']
+});
+
+await client.connect(transport);
+
+// Store memory
+await client.callTool({
+  name: 'openmemory_store',
+  arguments: {
+    content: "User prefers concise responses",
+    type: "both",
+    facts: [{
+      subject: "user_123",
+      predicate: "prefers_response_style",
+      object: "concise"
+    }],
+    user_id: "user_123"
+  }
+});
+
+// Query
+const result = await client.callTool({
+  name: 'openmemory_query',
+  arguments: {
+    query: "user preferences",
+    type: "unified",
+    user_id: "user_123"
+  }
+});
+```
+
+## Common Patterns
+
+### Track Evolving Preferences
+
+```json
+// Initial preference
+{
+  "content": "Client prefers PDF reports",
+  "type": "both",
+  "facts": [{"subject": "client_x", "predicate": "prefers_format", "object": "PDF"}]
+}
+
+// Updated preference (automatically invalidates old fact)
+{
+  "content": "Client now prefers Excel reports",
+  "type": "both",
+  "facts": [{"subject": "client_x", "predicate": "prefers_format", "object": "Excel"}]
+}
+
+// Query current preference
+{
+  "query": "client report format",
+  "type": "factual",
+  "fact_pattern": {"subject": "client_x", "predicate": "prefers_format"}
+}
+// Returns: Excel
+```
+
+### Historical Analysis
+
+```json
+// What was true last quarter?
+{
+  "query": "approval threshold in Q3",
+  "type": "factual",
+  "fact_pattern": {
+    "subject": "expense_policy",
+    "predicate": "approval_threshold_usd"
+  },
+  "at": "2023-09-30T00:00:00Z"
+}
+```
+
+### Comprehensive Context
+
+```json
+// Get both conversations and facts
+{
+  "query": "client requirements",
+  "type": "unified",
+  "fact_pattern": {"subject": "client_x"},
+  "k": 10
+}
+// Returns: Discussions + current facts
+```
+
+## Database Schema
+
+### Contextual Memory Tables
+- `memories` / `openmemory_memories` - Memory content and metadata
+- `vectors` / `openmemory_vectors` - Sector-specific embeddings
+- `waypoints` / `openmemory_waypoints` - Associative graph connections
+
+### Temporal Graph Tables
+- `temporal_facts` - Subject-predicate-object facts with validity periods
+- `temporal_edges` - Relationships between facts
+
+Both SQLite and Postgres are supported.
+
+## Troubleshooting
+
+### "Facts array is required" Error
+
+When using `type="factual"` or `type="both"`, you must provide the `facts` parameter:
+
+```json
+{
+  "content": "...",
+  "type": "factual",
+  "facts": [{ "subject": "...", "predicate": "...", "object": "..." }]
+}
+```
+
+### Empty Temporal Results
+
+If `type="factual"` returns no results:
+1. Verify facts were stored with correct subject/predicate
+2. Check `at` parameter matches validity period
+3. Use wildcards in fact_pattern to broaden search
+
+### Connection Issues
+
+Ensure environment variables are set:
+- Postgres: `OM_PG_HOST`, `OM_PG_DB`, `OM_PG_USER`, `OM_PG_PASSWORD`
+- Embeddings: `OPENAI_API_KEY` (or relevant provider key)
+
+## Performance
+
+- **Contextual queries:** ~50-200ms (vector similarity + graph traversal)
+- **Factual queries:** ~5-20ms (indexed SQL lookups)
+- **Unified queries:** Run in parallel, total ≈ max(contextual, factual)
+
+## See Also
+
+- [Node SDK](./node-sdk.md) - Direct API usage in Node.js applications
+- [Python SDK](./python-sdk.md) - Direct API usage in Python applications
+- [Getting Started](./getting-started.md) - Installation and setup guide

--- a/packages/openmemory-js/package-lock.json
+++ b/packages/openmemory-js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openmemory-js",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "openmemory-js",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "dependencies": {
                 "@aws-sdk/client-bedrock-runtime": "^3.932.0",
                 "@azure/msal-node": "^2.0.0",

--- a/packages/openmemory-js/src/core/db.ts
+++ b/packages/openmemory-js/src/core/db.ts
@@ -171,6 +171,33 @@ if (is_pg) {
             `create table if not exists "${sc}"."stats"(id serial primary key,type text not null,count integer default 1,ts bigint not null)`,
         );
         await pg.query(
+            `create table if not exists "${sc}"."temporal_facts"(id uuid primary key,subject text not null,predicate text not null,object text not null,valid_from bigint not null,valid_to bigint,confidence double precision not null check(confidence >= 0 and confidence <= 1),last_updated bigint not null,metadata text,unique(subject,predicate,object,valid_from))`,
+        );
+        await pg.query(
+            `create table if not exists "${sc}"."temporal_edges"(id uuid primary key,source_id uuid not null,target_id uuid not null,relation_type text not null,valid_from bigint not null,valid_to bigint,weight double precision not null,metadata text,foreign key(source_id) references "${sc}"."temporal_facts"(id),foreign key(target_id) references "${sc}"."temporal_facts"(id))`,
+        );
+        await pg.query(
+            `create index if not exists temporal_facts_subject_idx on "${sc}"."temporal_facts"(subject)`,
+        );
+        await pg.query(
+            `create index if not exists temporal_facts_predicate_idx on "${sc}"."temporal_facts"(predicate)`,
+        );
+        await pg.query(
+            `create index if not exists temporal_facts_validity_idx on "${sc}"."temporal_facts"(valid_from,valid_to)`,
+        );
+        await pg.query(
+            `create index if not exists temporal_facts_composite_idx on "${sc}"."temporal_facts"(subject,predicate,valid_from,valid_to)`,
+        );
+        await pg.query(
+            `create index if not exists temporal_edges_source_idx on "${sc}"."temporal_edges"(source_id)`,
+        );
+        await pg.query(
+            `create index if not exists temporal_edges_target_idx on "${sc}"."temporal_edges"(target_id)`,
+        );
+        await pg.query(
+            `create index if not exists temporal_edges_validity_idx on "${sc}"."temporal_edges"(valid_from,valid_to)`,
+        );
+        await pg.query(
             `create index if not exists openmemory_memories_sector_idx on ${m}(primary_sector)`,
         );
         await pg.query(


### PR DESCRIPTION
# Add Temporal Graph Support to MCP Tools

## 🎯 Summary

Exposes OpenMemory's temporal graph capabilities through MCP, enabling agents to store and query structured facts that change over time alongside contextual/HSG memories.

## 💡 Motivation

While OpenMemory has powerful temporal graph features for tracking facts over time (like Zep's Graphiti), these capabilities were only accessible via HTTP API. This PR brings temporal graph support to the MCP interface, allowing Claude, Cursor, Windsurf, and other MCP clients to leverage both:

1. **HSG Contextual Memory** - Rich semantic memory with sectors
2. **Temporal Facts** - Structured facts with automatic invalidation and historical queries

This enables agents to handle evolving information like:
- User preferences that change ("prefers Excel" → "prefers PDF")
- Business rules that evolve ("approval at $50K" → "approval at $75K")
- Historical queries ("What was the threshold in Q3?")

## 🔧 Changes

### 1. Database (Postgres Support for Temporal Graph)
**File:** `packages/openmemory-js/src/core/db.ts`

- ✅ Added `temporal_facts` table creation for Postgres
- ✅ Added `temporal_edges` table creation for Postgres
- ✅ Added 7 indexes for efficient temporal queries
- ✅ SQLite already had these tables; now Postgres parity achieved

### 2. Enhanced MCP Tools
**File:** `packages/openmemory-js/src/ai/mcp.ts`

**`openmemory_store` enhancements:**
- Added `type` parameter: `"contextual"` (default), `"factual"`, `"both"`
- Added `facts` array parameter for structured fact storage
- Backward compatible: calls without `type` default to HSG (contextual)
- Supports automatic fact invalidation (duplicate subject+predicate)

**`openmemory_query` enhancements:**
- Added `type` parameter: `"contextual"` (default), `"factual"`, `"unified"`
- Added `fact_pattern` parameter for temporal queries (subject/predicate/object with wildcards)
- Added `at` parameter for point-in-time historical queries
- Backward compatible: calls without `type` use HSG semantic search
- Unified type runs parallel queries to both systems

### 3. Documentation
**File:** `docs/mcp.md`

- Complete API reference for both tools
- Usage examples for all storage/query types
- Response format specifications
- Agent integration guidelines
- Best practices for fact naming conventions
- Troubleshooting guide

## 📋 API Examples

### Storage

```typescript
// Backward compatible (default: HSG only)
openmemory_store({ content: "User prefers quarterly reports" })

// Store temporal fact
openmemory_store({
  content: "Client prefers Excel format",
  type: "factual",
  facts: [{
    subject: "client_acme",
    predicate: "prefers_report_format",
    object: "Excel"
  }]
})

// Store in both systems
openmemory_store({
  content: "Budget threshold updated to $75K",
  type: "both",
  facts: [{
    subject: "expense_policy",
    predicate: "approval_threshold_usd",
    object: "75000"
  }]
})
```

### Queries

```typescript
// Backward compatible (default: HSG semantic search)
openmemory_query({ query: "user preferences" })

// Query current facts
openmemory_query({
  query: "client report preferences",
  type: "factual",
  fact_pattern: {
    subject: "client_acme",
    predicate: "prefers_report_format"
  }
})

// Historical query
openmemory_query({
  query: "what was threshold in Q3",
  type: "factual",
  fact_pattern: {
    subject: "expense_policy",
    predicate: "approval_threshold_usd"
  },
  at: "2023-09-30T00:00:00Z"
})

// Unified query (both systems)
openmemory_query({
  query: "client information",
  type: "unified",
  fact_pattern: { subject: "client_acme" }
})
```

## ✅ Backward Compatibility

- ✅ No breaking changes: All existing MCP calls work unchanged
- ✅ Optional parameters: `type` defaults to existing behavior
- ✅ Legacy format support: Parser handles both old and new response formats
- ✅ Graceful degradation: Errors in temporal queries don't break HSG functionality

## Benefits

For Users:

- Track evolving preferences and business rules
- Query historical states ("What did I prefer last month?")
- More structured, queryable memory
- Automatic handling of fact changes

For Developers:

- Clean separation: contextual vs. factual storage
- Backward compatible integration
- Type-safe fact structure
- Comprehensive documentation

## Migration Notes

No migration needed. This is additive - existing HSG functionality unchanged.

To use new features, agents should:

1. Add `type` parameter to `openmemory_store` calls when storing facts
2. Provide `facts` array with subject-predicate-object triples
3. Use `type="factual"` or `type="unified"` for temporal queries
4. Construct `fact_pattern` for targeted fact retrieval

## Example Output

```javascript
Query: "gitlab mcp project preferences"
Type: unified

Results:
- 8 contextual memories (conversations, context)
- 5 temporal facts (structured preferences)

Both returned in single call for comprehensive context.
```

### Memory/Facts Creation
<img width="474" height="872" alt="image" src="https://github.com/user-attachments/assets/cdbcf1aa-d61c-44e2-8784-f489b46e9514" />

### Memory/Facts Retrieval
<img width="487" height="981" alt="image" src="https://github.com/user-attachments/assets/aef0c721-7e1b-47e8-83ef-82ec7c3da272" />


