### PR TITLE
fix: use absolute /data path for SQLite in .env.example to match Docker volume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ OM_MODE=standard # standard | langgraph
 # --------------------------------------------
 # sqlite (default) | postgres
 OM_METADATA_BACKEND=sqlite
-OM_DB_PATH=./data/openmemory.sqlite
+OM_DB_PATH=/data/openmemory.sqlite
 
 # PostgreSQL Settings (used when OM_METADATA_BACKEND=postgres)
 OM_PG_HOST=localhost


### PR DESCRIPTION
Closes #135

The `.env.example` sets `OM_DB_PATH=./data/openmemory.sqlite` (relative path), but the Docker volume in `docker-compose.yml` is mounted at `/data`. When users copy `.env.example` to `.env`, the SQLite file is created at `./data/` inside the container (not on the mounted volume), causing all data to be lost on container restart.

This fix changes the example path to `/data/openmemory.sqlite` (absolute) to match the volume mount point.