### PR TITLE
fix: correct broken link to API docs in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -809,4 +809,4 @@ Query `embed_logs` table for:
 - [Why.md](./Why.md) - Architectural rationale
 - [CONTRIBUTING.md](./CONTRIBUTING.md) - Development guide
 - [SECURITY.md](./SECURITY.md) - Security policy
-- [API Documentation](./docs/api.md) - Endpoint details
+- [API Documentation](./docs/api-server.md) - Endpoint details


### PR DESCRIPTION
## Summary

The `ARCHITECTURE.md` references section links to `./docs/api.md` (line 812), but this file doesn't exist. The correct path is `./docs/api-server.md`.

## Change

```diff
-- [API Documentation](./docs/api.md) - Endpoint details
+- [API Documentation](./docs/api-server.md) - Endpoint details
```