### PR TITLE
fix: include dev dependencies in Render build

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: openmemory
     env: node
     rootDir: packages/openmemory-js
-    buildCommand: npm install && npm run build
+    buildCommand: npm install --include=dev && npm run build
     startCommand: npm start
     plan: free
     autoDeploy: true


### PR DESCRIPTION
## Summary
- update the Render build command to install dev dependencies before running the TypeScript build
- fix deploys where `NODE_ENV=production` causes `npm install` to skip `typescript` and the `@types/*` packages needed by `tsc`

## Reproduction
With the current `render.yaml` settings:
- `rootDir: packages/openmemory-js`
- `NODE_ENV=production`
- `buildCommand: npm install && npm run build`

A production install omits dev dependencies, so the build fails locally with:
- `sh: 1: tsc: not found`

That matches the reported Render deployment failure pattern.

## Testing
- `cd packages/openmemory-js && NODE_ENV=production npm install --ignore-scripts --no-audit --no-fund && npm run build` *(fails before this change because dev dependencies are skipped)*
- `cd packages/openmemory-js && npm install --include=dev --ignore-scripts --no-audit --no-fund && npm run build` *(passes)*

Closes #142
