### PR TITLE
docs: fix dashboard backend source paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ git clone https://github.com/CaviraOSS/OpenMemory.git
 cd OpenMemory
 cp .env.example .env
 
-cd backend
+cd packages/openmemory-js
 npm install
 npm run dev   # default :8080
 ```

--- a/dashboard/CHAT_SETUP.md
+++ b/dashboard/CHAT_SETUP.md
@@ -17,7 +17,7 @@ The chat interface is now connected to the OpenMemory backend and can query memo
 First, make sure the OpenMemory backend is running:
 
 ```bash
-cd backend
+cd packages/openmemory-js
 npm install
 npm run dev
 ```


### PR DESCRIPTION
## Summary
- update the root README source-run instructions to use `packages/openmemory-js` instead of the removed `backend` directory
- update `dashboard/CHAT_SETUP.md` to point the dashboard setup guide at the same real backend path

## Why
Issue #133 reports that the dashboard exists in the repo but is not actually consumable in non-Docker installs.

One concrete source of confusion is that the repository docs still instruct users to run the backend from:

```bash
cd backend
```

But the current repository layout uses:

```bash
cd packages/openmemory-js
```

Fixing these paths removes a guaranteed setup failure in the source-based dashboard flow.

## Testing
- verified the repo no longer contains `cd backend` in the updated source-run instructions
- confirmed both docs now point to `packages/openmemory-js`

Related to #133
