### PR TITLE
fix: honor IDE allowed origins for IDE routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ git clone https://github.com/CaviraOSS/OpenMemory.git
 cd OpenMemory
 cp .env.example .env
 
-cd backend
+cd packages/openmemory-js
 npm install
 npm run dev   # default :8080
 ```

--- a/dashboard/CHAT_SETUP.md
+++ b/dashboard/CHAT_SETUP.md
@@ -17,7 +17,7 @@ The chat interface is now connected to the OpenMemory backend and can query memo
 First, make sure the OpenMemory backend is running:
 
 ```bash
-cd backend
+cd packages/openmemory-js
 npm install
 npm run dev
 ```

--- a/packages/openmemory-js/src/server/index.ts
+++ b/packages/openmemory-js/src/server/index.ts
@@ -41,7 +41,19 @@ if (env.emb_kind !== "synthetic" && (tier === "hybrid" || tier === "fast")) {
 app.use(req_tracker_mw());
 
 app.use((req: any, res: any, next: any) => {
-    res.setHeader("Access-Control-Allow-Origin", "*");
+    const origin = req.headers.origin;
+    const isIdeRoute = (req.path || req.url || "").startsWith("/api/ide/");
+    const allowIdeOrigin =
+        env.ide_mode &&
+        typeof origin === "string" &&
+        env.ide_allowed_origins.includes(origin);
+
+    if (isIdeRoute && allowIdeOrigin) {
+        res.setHeader("Access-Control-Allow-Origin", origin);
+        res.setHeader("Vary", "Origin");
+    } else {
+        res.setHeader("Access-Control-Allow-Origin", "*");
+    }
     res.setHeader(
         "Access-Control-Allow-Methods",
         "GET,POST,PUT,PATCH,DELETE,OPTIONS",


### PR DESCRIPTION
## Summary
- wire `OM_IDE_ALLOWED_ORIGINS` into the server CORS handling for `/api/ide/*` routes
- return the requesting origin for IDE requests when `OM_IDE_MODE=true` and the origin is explicitly allowlisted
- keep the existing permissive fallback for non-IDE routes

## Why
Issue #123 reports that OpenMemory does not work with Claude in Antigravity.

While tracing the IDE/MCP integration path, I found that:
- `OM_IDE_MODE` and `OM_IDE_ALLOWED_ORIGINS` are defined in config
- but `ide_allowed_origins` was never actually consumed by the server
- all routes always returned `Access-Control-Allow-Origin: *`

This patch makes the IDE-specific allowlist configuration live for `/api/ide/*` requests instead of leaving it as a dead config knob.

## Testing
- `cd packages/openmemory-js && npm run build`

Related to #123
