### PR TITLE
fix(dashboard): add process-level error safety net

### DIFF
--- a/dashboard/instrumentation.ts
+++ b/dashboard/instrumentation.ts
@@ -1,0 +1,21 @@
+// Backstop for bugs that would otherwise stall the Node event loop and
+// leave the container accepting TCP but never responding (502 from Caddy).
+// Not a substitute for fixing the underlying faults — log and keep serving
+// so Docker's health check and orchestration can decide when to cycle us.
+declare global {
+  var __om_handlers_registered: boolean | undefined
+}
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return
+  if (globalThis.__om_handlers_registered) return
+  globalThis.__om_handlers_registered = true
+
+  process.on('uncaughtException', (err) => {
+    console.error('uncaughtException', err)
+  })
+
+  process.on('unhandledRejection', (reason: unknown) => {
+    console.error('unhandledRejection', reason)
+  })
+}


### PR DESCRIPTION
## Summary

Add `dashboard/instrumentation.ts` registering `uncaughtException` and `unhandledRejection` handlers on the Node runtime. Defends against the failure mode where the dashboard container stays `Up` but its HTTP listener accepts TCP and never responds, surfacing as 502 from the reverse proxy until a manual `docker restart`.

- Guarded against duplicate registration via a global flag (HMR reloads / repeated `register()` calls won't stack listeners).
- Log-and-keep-serving is intentional: exit-on-throw would convert every stray rejection into a restart outage window, which is worse than the wedge for a stateless dashboard. Documented in a header comment.

## Root cause notes

Audited the tree for the two specific bugs reported in prod logs:

1. **`ReferenceError: returnNaN is not defined`** — `grep -rn "returnNaN"` and `grep -rn "NaN"` across `app/`, `components/`, `lib/` return zero hits on current `main`.
2. **Uncaught `EACCES` on `/let`, `/var/let`, `/etc/let`** — only `fs.*` calls are in `app/api/settings/route.ts`, which reads a hardcoded `ENV_PATH = path.resolve(process.cwd(), '../.env')`. No route passes `req` / `params` / `query` / `searchParams` into `fs.*` or `path.resolve`/`path.join`. No user-controlled path reaches the FS.

Neither fault is reproducible from source. This PR is purely the backstop the symptom report called out — if the deployed revision hits an uncaught throw from a dep or a future regression, it logs instead of stalling the event loop.

## Test plan

- [x] `cd dashboard && npm run build` passes.
- [ ] `docker compose build dashboard && docker compose up -d dashboard` on deploy host.
- [ ] `curl` health check returns 200; container reports healthy.
- [ ] Path-traversal probes return 4xx and server stays up.
- [ ] `docker logs` shows no uncaughtException / returnNaN.