### PR TITLE
fix: replace deprecated Gemini embedding model (text-embedding-004 → gemini-embedding-001)

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -8,35 +8,35 @@
 episodic:
   ollama: nomic-embed-text
   openai: text-embedding-3-small
-  gemini: models/text-embedding-004
+  gemini: models/gemini-embedding-001
   aws: amazon.titan-embed-text-v2:0
   local: all-MiniLM-L6-v2
 
 semantic:
   ollama: nomic-embed-text
   openai: text-embedding-3-small
-  gemini: models/text-embedding-004
+  gemini: models/gemini-embedding-001
   aws: amazon.titan-embed-text-v2:0
   local: all-MiniLM-L6-v2
 
 procedural:
   ollama: nomic-embed-text
   openai: text-embedding-3-small
-  gemini: models/text-embedding-004
+  gemini: models/gemini-embedding-001
   aws: amazon.titan-embed-text-v2:0
   local: all-MiniLM-L6-v2
 
 emotional:
   ollama: nomic-embed-text
   openai: text-embedding-3-small
-  gemini: models/text-embedding-004
+  gemini: models/gemini-embedding-001
   aws: amazon.titan-embed-text-v2:0
   local: all-MiniLM-L6-v2
 
 reflective:
   ollama: nomic-embed-text
   openai: text-embedding-3-large
-  gemini: models/text-embedding-004
+  gemini: models/gemini-embedding-001
   aws: amazon.titan-embed-text-v2:0
   local: all-mpnet-base-v2
 # Available Ollama models (pull with: ollama pull <model>)
@@ -50,7 +50,8 @@ reflective:
 # - text-embedding-3-large (3072d)
 
 # Gemini models:
-# - models/text-embedding-004 (768d) - latest
+# - models/gemini-embedding-001 (3072d native, configurable via outputDimensionality) - current GA
+# - models/text-embedding-004 (768d) - deprecated, returns 404
 # - models/embedding-001 (768d) - deprecated
 
 #AWS models:

--- a/packages/openmemory-js/src/core/models.ts
+++ b/packages/openmemory-js/src/core/models.ts
@@ -51,7 +51,7 @@ const get_defaults = (): model_cfg => ({
     episodic: {
         ollama: "nomic-embed-text",
         openai: "text-embedding-3-small",
-        gemini: "models/embedding-001",
+        gemini: "models/gemini-embedding-001",
         aws: "amazon.titan-embed-text-v2:0",
         siray: "text-embedding-3-small",
         local: "all-MiniLM-L6-v2",
@@ -59,7 +59,7 @@ const get_defaults = (): model_cfg => ({
     semantic: {
         ollama: "nomic-embed-text",
         openai: "text-embedding-3-small",
-        gemini: "models/embedding-001",
+        gemini: "models/gemini-embedding-001",
         aws: "amazon.titan-embed-text-v2:0",
         siray: "text-embedding-3-small",
         local: "all-MiniLM-L6-v2",
@@ -67,21 +67,21 @@ const get_defaults = (): model_cfg => ({
     procedural: {
         ollama: "nomic-embed-text",
         openai: "text-embedding-3-small",
-        gemini: "models/embedding-001",
+        gemini: "models/gemini-embedding-001",
         aws: "amazon.titan-embed-text-v2:0",
         local: "all-MiniLM-L6-v2",
     },
     emotional: {
         ollama: "nomic-embed-text",
         openai: "text-embedding-3-small",
-        gemini: "models/embedding-001",
+        gemini: "models/gemini-embedding-001",
         aws: "amazon.titan-embed-text-v2:0",
         local: "all-MiniLM-L6-v2",
     },
     reflective: {
         ollama: "nomic-embed-text",
         openai: "text-embedding-3-large",
-        gemini: "models/embedding-001",
+        gemini: "models/gemini-embedding-001",
         aws: "amazon.titan-embed-text-v2:0",
         local: "all-mpnet-base-v2",
     },

--- a/packages/openmemory-js/src/memory/embed.ts
+++ b/packages/openmemory-js/src/memory/embed.ts
@@ -307,11 +307,11 @@ async function emb_gemini(
 ): Promise<Record<string, number[]>> {
     if (!env.gemini_key) throw new Error("Gemini key missing");
     const prom = gem_q.then(async () => {
-        const url = `https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:batchEmbedContents?key=${env.gemini_key}`;
+        const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents?key=${env.gemini_key}`;
         for (let a = 0; a < 3; a++) {
             try {
                 const reqs = Object.entries(txts).map(([s, t]) => ({
-                    model: "models/text-embedding-004",
+                    model: "models/gemini-embedding-001",
                     content: { parts: [{ text: t }] },
                     taskType: task_map[s] || task_map.semantic,
                 }));
@@ -705,7 +705,7 @@ export const getEmbeddingInfo = () => {
     } else if (env.emb_kind === "gemini") {
         i.configured = !!env.gemini_key;
         i.batch_api = env.embed_mode === "simple";
-        i.model = "embedding-001";
+        i.model = "gemini-embedding-001";
     } else if (env.emb_kind === "aws") {
         i.configured =
             !!env.AWS_REGION &&


### PR DESCRIPTION
## Problem

`text-embedding-004` is no longer served by Google's Generative Language API. Calls to `/v1beta/models/text-embedding-004:batchEmbedContents` (and the single-contentvariant) return **HTTP 404** for newly-issued API keys.

This means a fresh deployment of OpenMemory configured with `OM_EMBEDDINGS=gemini` falls back to synthetic embeddings on every call. Logs look like:

```
[EMBED] Provider: gemini, Tier: smart, Sector: semantic
[EMBED] Gemini error (1/3): Gemini: 404
[EMBED] Gemini error (2/3): Gemini: 404
[EMBED] Gemini batch failed, falling back to sequential: Error: Gemini failed after 3 attempts: Gemini: 404
[EMBED] gemini failed: Gemini failed after 3 attempts: Gemini: 404, trying synthetic
[EMBED] Fallback to synthetic succeeded for sector: semantic
```

The fallback is silent at the API surface (queries still return), but recall quality drops to the synthetic baseline — semantic search effectively stops working.

Verified against the live API on 2026-05-09 with a fresh AI Studio key:
```
GET  /v1beta/models?key=…
→ models/gemini-embedding-001        ✅ supports embedContent, asyncBatchEmbedContent
   models/gemini-embedding-2-preview ✅
   models/gemini-embedding-2         ✅
   (text-embedding-004 / embedding-001 are not listed)

POST /v1beta/models/text-embedding-004:embedContent     → 404
POST /v1beta/models/gemini-embedding-001:embedContent   → 200, returns vector
POST /v1beta/models/gemini-embedding-001:batchEmbedContents → 200
```

The older `embedding-001` (which `get_defaults()` in `core/models.ts` falls back to) is also deprecated.

## Fix

Replace both deprecated model names with `gemini-embedding-001` in three places:

| File | Change |
|---|---|
| `packages/openmemory-js/src/memory/embed.ts` | Hardcoded URL + request-body `model` field in `emb_gemini()` (lines 310, 314), and the `getEmbeddingInfo()` self-report (line 708). |
| `models.yml` | `gemini:` entry for all 5 sectors + the documentation comment block at the bottom. |
| `packages/openmemory-js/src/core/models.ts` | `get_defaults()` fallback for all 5 sectors. |

`gemini-embedding-001` exposes the same `batchEmbedContents` endpoint with the same request body shape (`model`, `content`, `taskType`); the response vectors get resized to `env.vec_dim` via the existing `resize_vec` helper, so no caller-side changes are needed.

## Verification

Tested on a smart-tier deployment with 159 existing memories:
- Pre-fix: every Gemini call 404s, queries fall through to synthetic.
- Post-fix: queries return semantically-ranked matches in <1s, no errors in logs. Paraphrase queries (`"travel plans next week"` → matches a `Pre-Miami plan on track` memory with no shared keywords) confirm real semantic recall, not lexical fallback.

## Out of scope (follow-up)

The `emb_gemini()` function does not call `get_model(s, "gemini")` like every other provider — it hardcodes the model name in the URL. That means `models.yml`'s `gemini:` entries are loaded by `models.ts` but never read by the Gemini path. A separate PR should refactor `emb_gemini` to use `get_model` (and ideally also support a per-call `outputDimensionality` query param). I left that out of this PR to keep the scope to a model-name correction.

Also worth considering: an `OM_GEMINI_MODEL` env override (mirroring `OM_OPENAI_MODEL` / `OM_OLLAMA_MODEL`) so users can opt into `gemini-embedding-2` without code changes.