### PR TITLE
feat: add CLIENT SETNAME for connection identification

### DIFF
--- a/packages/openmemory-js/src/core/vector/valkey.ts
+++ b/packages/openmemory-js/src/core/vector/valkey.ts
@@ -11,6 +11,7 @@ export class ValkeyVectorStore implements VectorStore {
             host: env.valkey_host || "localhost",
             port: env.valkey_port || 6379,
             password: env.valkey_password,
+            connectionName: "openmemory_vector_store_client",
         });
     }
 


### PR DESCRIPTION
## 📋 Description

Adds `connectionName: "openmemory_vector_store_client"` to the ioredis client options in `valkey.ts` so the connection is identifiable via `CLIENT LIST` on the server.

Fixes #182

## 🔄 Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## 🧪 Testing
- [x] I have tested this change locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## 🔍 Code Review Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of the code has been performed
- [x] Changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## 📚 Related Issues

Fixes #182

## 📋 Additional Context

`connectionName` is a standard ioredis option that sends `CLIENT SETNAME` on connection. Zero-risk — metadata only, no behavioral changes. Makes the connection identifiable in `CLIENT LIST`, monitoring dashboards, and CloudWatch metrics.
