### PR TITLE
feat(openmemory-py): upgrade MiniMax default chat model to M3

### DIFF
--- a/packages/openmemory-py/README.md
+++ b/packages/openmemory-py/README.md
@@ -180,7 +180,7 @@ embeddings={
 }
 ```
 
-> uses MiniMax's `embo-01` model (1536 dimensions). for chat completions, MiniMax supports `MiniMax-M2.7` and `MiniMax-M2.5-highspeed` via OpenAI-compatible API.
+> uses MiniMax's `embo-01` model (1536 dimensions). for chat completions, MiniMax supports `MiniMax-M3` (default), `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed` via OpenAI-compatible API.
 
 #### aws bedrock
 ```python

--- a/packages/openmemory-py/src/openmemory/ai/minimax.py
+++ b/packages/openmemory-py/src/openmemory/ai/minimax.py
@@ -19,7 +19,7 @@ class MiniMaxAdapter(AIAdapter):
         self.client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
 
     async def chat(self, messages: List[Dict[str, str]], model: str = None, **kwargs) -> str:
-        m = model or env.minimax_model or "MiniMax-M2.7"
+        m = model or env.minimax_model or "MiniMax-M3"
         temperature = kwargs.pop("temperature", None)
         if temperature is not None:
             temperature = max(0.0, min(float(temperature), 1.0))

--- a/packages/openmemory-py/tests/test_minimax.py
+++ b/packages/openmemory-py/tests/test_minimax.py
@@ -71,7 +71,7 @@ class TestMiniMaxChat:
             await adapter.chat([{"role": "user", "content": "test"}])
 
         call_kwargs = adapter.client.chat.completions.create.call_args
-        assert call_kwargs.kwargs["model"] == "MiniMax-M2.7"
+        assert call_kwargs.kwargs["model"] == "MiniMax-M3"
 
     @pytest.mark.asyncio
     async def test_chat_custom_model(self):
@@ -87,10 +87,10 @@ class TestMiniMaxChat:
 
         await adapter.chat(
             [{"role": "user", "content": "test"}],
-            model="MiniMax-M2.5-highspeed",
+            model="MiniMax-M2.7-highspeed",
         )
         call_kwargs = adapter.client.chat.completions.create.call_args
-        assert call_kwargs.kwargs["model"] == "MiniMax-M2.5-highspeed"
+        assert call_kwargs.kwargs["model"] == "MiniMax-M2.7-highspeed"
 
     @pytest.mark.asyncio
     async def test_chat_temperature_clamping(self):
@@ -408,7 +408,7 @@ class TestMiniMaxIntegrationChat:
         adapter = MiniMaxAdapter(api_key=api_key)
         result = await adapter.chat(
             [{"role": "user", "content": "Say 'hello' and nothing else."}],
-            model="MiniMax-M2.5-highspeed",
+            model="MiniMax-M2.7-highspeed",
             temperature=0.0,
         )
         assert isinstance(result, str)


### PR DESCRIPTION
## Summary

Upgrade the `MiniMax` adapter in `openmemory-py` to default to the new
flagship `MiniMax-M3` model. `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`
remain available as explicit alternatives.

## Changes

- `packages/openmemory-py/src/openmemory/ai/minimax.py`: change the fallback
  default chat model from `MiniMax-M2.7` to `MiniMax-M3` (still overridable
  via the `model=` argument or `OM_MINIMAX_MODEL` env var).
- `packages/openmemory-py/tests/test_minimax.py`:
  - Update the default-model assertion to expect `MiniMax-M3`.
  - Switch the custom-model unit test and the integration smoke test to use
    `MiniMax-M2.7-highspeed`, the still-supported low-latency variant.
- `packages/openmemory-py/README.md`: refresh the minimax section to list
  `MiniMax-M3` (default), `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed`.

## Why

`MiniMax-M3` is the current flagship chat model. Pointing the default at it
means new users get the latest capabilities (longer context, better quality)
out of the box, while users who pin a specific model can still pick the
M2.7 variants.

## Testing

- `pytest tests/test_minimax.py -k "not Integration"` — all 24 unit tests
  pass.
- Spot-checked both `MiniMax-M3` (default) and `MiniMax-M2.7-highspeed`
  against `https://api.minimax.io/v1` — both are accepted by the API.

No changes to embeddings, base URL, env vars, or temperature handling.