### PR TITLE
feat(dashboard): proxy OpenMemory API server-side

### DIFF
--- a/dashboard/.env.local.example
+++ b/dashboard/.env.local.example
@@ -1,4 +1,11 @@
 # OpenMemory Dashboard Configuration
-NEXT_PUBLIC_API_URL=http://localhost:8080
-# Set this if your backend has OM_API_KEY configured for authentication
-NEXT_PUBLIC_API_KEY=your
+
+# Recommended: browser calls the dashboard's same-origin server-side proxy.
+# The API key stays server-side and is never exposed in the browser bundle.
+OPENMEMORY_API_URL=http://localhost:8080
+# OPENMEMORY_API_KEY=your-secret-api-key
+
+# Optional legacy/browser-direct mode: set this only when you intentionally want
+# the browser to call the backend directly. Any NEXT_PUBLIC_* value is public.
+# NEXT_PUBLIC_API_URL=http://localhost:8080
+# NEXT_PUBLIC_API_KEY=your-public-or-dev-api-key

--- a/dashboard/CHAT_SETUP.md
+++ b/dashboard/CHAT_SETUP.md
@@ -26,12 +26,16 @@ The backend will start on `http://localhost:8080`
 
 ### 2. Configure Environment (Optional)
 
-The dashboard is pre-configured to connect to `localhost:8080`. If your backend runs on a different port, create a `.env.local` file:
+The dashboard is pre-configured to use its same-origin server-side proxy at `/api/openmemory`.
+If your backend runs on a different port, create a `.env.local` file:
 
 ```bash
 # dashboard/.env.local
-NEXT_PUBLIC_API_URL=http://localhost:8080
+OPENMEMORY_API_URL=http://localhost:8080
+# OPENMEMORY_API_KEY=your-secret-api-key
 ```
+
+This keeps backend API keys server-side. For local development only, you can set `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_API_KEY` to make the browser call the backend directly, but `NEXT_PUBLIC_*` values are public in the browser bundle.
 
 ### 3. Start the Dashboard
 
@@ -137,7 +141,7 @@ Clicking the **+** button on a memory card:
 ### Connection refused
 
 - Backend not started
-- Wrong port in `.env.local`
+- Wrong port in `.env.local` (`OPENMEMORY_API_URL` for server-side proxy mode, or `NEXT_PUBLIC_API_URL` for browser-direct mode)
 - Firewall blocking connection
 
 ## API Endpoints Used

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -20,8 +20,15 @@ npm install
 npm run dev
 ```
 
-By default the dashboard expects the backend at `http://localhost:8080`.
-If you use a different backend URL, configure it in `.env.local` as described in `CHAT_SETUP.md`.
+By default the dashboard calls its same-origin server-side proxy at `/api/openmemory`, which forwards requests to the OpenMemory backend.
+Configure the backend URL and optional API key in `.env.local`:
+
+```env
+OPENMEMORY_API_URL=http://localhost:8080
+# OPENMEMORY_API_KEY=your-secret-api-key
+```
+
+This keeps authenticated backend API keys on the server. For local development only, you can still use browser-direct configuration with `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_API_KEY`, but `NEXT_PUBLIC_*` values are public in the browser bundle.
 
 ## Run the dashboard locally
 

--- a/dashboard/app/api/openmemory/[...path]/route.ts
+++ b/dashboard/app/api/openmemory/[...path]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from 'next/server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const BACKEND = (process.env.OPENMEMORY_API_URL || 'http://127.0.0.1:9432').replace(/\/+$/, '')
+const API_KEY = process.env.OPENMEMORY_API_KEY || process.env.OM_API_KEY || ''
+
+async function proxy(req: NextRequest, ctx: { params: Promise<{ path?: string[] }> }) {
+    const { path = [] } = await ctx.params
+    const target = new URL(`${BACKEND}/${path.map(encodeURIComponent).join('/')}`)
+    req.nextUrl.searchParams.forEach((value, key) => target.searchParams.append(key, value))
+
+    const headers = new Headers()
+    const accept = req.headers.get('accept')
+    const contentType = req.headers.get('content-type')
+    if (accept) headers.set('accept', accept)
+    if (contentType) headers.set('content-type', contentType)
+    if (API_KEY) headers.set('x-api-key', API_KEY)
+
+    const init: RequestInit = {
+        method: req.method,
+        headers,
+        redirect: 'manual',
+        cache: 'no-store',
+    }
+    if (!['GET', 'HEAD'].includes(req.method)) {
+        init.body = await req.arrayBuffer()
+    }
+
+    const res = await fetch(target, init)
+    const outHeaders = new Headers(res.headers)
+    outHeaders.delete('content-encoding')
+    outHeaders.delete('content-length')
+    outHeaders.delete('transfer-encoding')
+    outHeaders.set('cache-control', 'no-store')
+    return new Response(res.body, { status: res.status, statusText: res.statusText, headers: outHeaders })
+}
+
+export const GET = proxy
+export const POST = proxy
+export const PUT = proxy
+export const PATCH = proxy
+export const DELETE = proxy
+export const OPTIONS = proxy

--- a/dashboard/components/navbar.tsx
+++ b/dashboard/components/navbar.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import { useProject } from "@/lib/project-context"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api/openmemory"
 
 export default function Navbar() {
     const [backendStatus, setBackendStatus] = useState<'online' | 'offline' | 'checking'>('checking')

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1,9 +1,7 @@
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api/openmemory'
 
 export const getHeaders = () => {
-    const apiKey = process.env.NEXT_PUBLIC_API_KEY
     return {
         'Content-Type': 'application/json',
-        ...(apiKey && { 'x-api-key': apiKey }),
     }
 }


### PR DESCRIPTION
## Why

The dashboard can currently be configured to send an authenticated OpenMemory backend API key from the browser using `NEXT_PUBLIC_API_KEY`.

That works for local development, but every `NEXT_PUBLIC_*` value is bundled into the frontend and can be inspected by anyone who can access the dashboard JavaScript or browser DevTools.

For deployments where the OpenMemory backend is protected with `OM_API_KEY`, this means the dashboard has to expose the backend API key to the browser in order to work. That is not ideal for production deployments or dashboards behind SSO/reverse proxies.

## What this PR changes

This PR adds a same-origin server-side proxy route to the dashboard:

```text
Browser -> /api/openmemory/... -> Next.js route handler -> OpenMemory backend
```

The route handler forwards requests to `OPENMEMORY_API_URL` and, when configured, injects `OPENMEMORY_API_KEY` server-side as `x-api-key`.

This lets the dashboard talk to authenticated OpenMemory backends without putting the backend API key in the browser bundle.

## Configuration modes

### Recommended mode: server-side proxy

```env
OPENMEMORY_API_URL=http://localhost:8080
OPENMEMORY_API_KEY=your-secret-api-key
```

In this mode the browser calls `/api/openmemory/...`, and the API key stays on the server.

### Legacy/dev mode: browser-direct backend access

```env
NEXT_PUBLIC_API_URL=http://localhost:8080
NEXT_PUBLIC_API_KEY=your-dev-api-key
```

This mode is still supported for local development or intentionally public backends, but `NEXT_PUBLIC_*` values are public by design.

## Security impact

This does not replace application-level auth, SSO, or network controls.

It does reduce accidental credential exposure by allowing authenticated backend deployments to keep their API key server-side instead of embedding it into the frontend bundle.

## Docs updated

- `dashboard/.env.local.example`
- `dashboard/README.md`
- `dashboard/CHAT_SETUP.md`

## Validation

Tested locally with an authenticated backend:

- `npm run build`
- `curl http://127.0.0.1:3030/api/openmemory/memory/all?l=1&u=0` returned `200 OK`
- scanned `.next/static` and `.next/server` for `NEXT_PUBLIC_API_KEY` and deployed key values: not found
