### PR TITLE
refactor: Add return type annotation to getHeaders

### DIFF
--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1,6 +1,6 @@
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api/openmemory'
 
-export const getHeaders = () => {
+export const getHeaders = (): { 'Content-Type': string } => {
     return {
         'Content-Type': 'application/json',
     }


### PR DESCRIPTION
### 问题背景

在 `dashboard/lib/api.ts` 文件中，公共函数 `getHeaders` 缺少明确的返回类型注解。虽然 TypeScript 能够根据返回值推断类型，但为公共函数添加显式类型注解是 TypeScript 代码的最佳实践。这能提高代码的可读性、可维护性，并为未来的重构或类型检查提供更清晰的契约。

### 修改内容

- **修改了什么**: 为 `getHeaders` 函数添加了明确的返回类型注解 `: { 'Content-Type': string }`。
- **为什么这样改**: 明确的返回类型注解使得函数的输出一目了然，无需深入函数实现即可知晓其返回结构。这对于代码审查、工具链支持（如自动补全）以及防止意外的返回类型变化都有积极意义。
- **对代码质量的提升**: 增强了类型安全性和代码可读性，符合严格的 TypeScript 项目规范。

### 验证方式

- **现有测试**: 此次修改是纯粹的类型注解添加，不改变任何运行时行为。因此，所有现有的测试套件应继续通过。
- **新增测试**: 无需为此次纯类型修改添加新的测试。
- **手动验证**: 确认修改后的文件可以通过 TypeScript 编译器（`tsc`）的类型检查，并且 IDE（如 VS Code）能够正确识别函数类型。

### 其他信息

- **Breaking Changes**: 无。此修改不改变函数签名、行为或公共 API。
- **文档更新**: 无需更新。
- **已知限制**: 无。