### PR TITLE
fix(cli): repair opm query and stop flags leaking into memory text

### DIFF
--- a/packages/openmemory-js/bin/opm.js
+++ b/packages/openmemory-js/bin/opm.js
@@ -103,14 +103,15 @@ const querymem = async (txt, opts) => {
     method: 'POST',
     body: JSON.stringify(body),
   });
-  console.log(`[results] ${r.memories.length} found\n`);
-  r.memories.forEach((m, i) => {
+  const items = r.matches || r.memories || [];
+  console.log(`[results] ${items.length} found\n`);
+  items.forEach((m, i) => {
     console.log(`${i + 1}. [${m.primary_sector}] ${m.content}`);
     console.log(`   id: ${m.id}`);
     console.log(
-      `   score: ${m.score?.toFixed(3) || 'n/a'} | sal: ${m.salience.toFixed(
-        3,
-      )}`,
+      `   score: ${m.score?.toFixed(3) ?? 'n/a'} | sal: ${
+        m.salience?.toFixed(3) ?? 'n/a'
+      }`,
     );
     if (m.tags) console.log(`   tags: ${m.tags}`);
     console.log();
@@ -191,10 +192,17 @@ const health = async () => {
 const argv = process.argv.slice(2);
 const cmd = argv[0];
 
-if (!cmd || cmd === '--help' || cmd === '-h') {
+// --help anywhere wins: otherwise `opm add --help` stores "--help" as a memory
+if (!cmd || argv.includes('--help') || argv.includes('-h')) {
   console.log(helptext);
   process.exit(0);
 }
+
+// positional text = everything after the command up to the first --flag
+const textargs = () => {
+  const stop = argv.findIndex((a, i) => i > 0 && a.startsWith('--'));
+  return argv.slice(1, stop === -1 ? argv.length : stop).join(' ');
+};
 
 const opts = {};
 for (let i = 1; i < argv.length; i++) {
@@ -207,20 +215,18 @@ for (let i = 1; i < argv.length; i++) {
 (async () => {
   try {
     switch (cmd) {
-      case 'add':
-        if (!argv[1]) throw new Error('content required: opm add "text"');
-        await addmem(
-          argv.slice(1, argv.indexOf('--')).join(' ') || argv[1],
-          opts,
-        );
+      case 'add': {
+        const text = textargs();
+        if (!text) throw new Error('content required: opm add "text"');
+        await addmem(text, opts);
         break;
-      case 'query':
-        if (!argv[1]) throw new Error('query text required: opm query "text"');
-        await querymem(
-          argv.slice(1, argv.indexOf('--')).join(' ') || argv[1],
-          opts,
-        );
+      }
+      case 'query': {
+        const q = textargs();
+        if (!q) throw new Error('query text required: opm query "text"');
+        await querymem(q, opts);
         break;
+      }
       case 'list':
         await listmem(opts);
         break;


### PR DESCRIPTION
## Summary

Three user-visible bugs in the `opm` CLI (`packages/openmemory-js/bin/opm.js`), all hit in a single session of normal use.

### 1. `opm query` crashed on every invocation

```
$ opm query "anything"
[error] Cannot read properties of undefined (reading 'length')
```

`querymem` read results from `r.memories`, but `/memory/query` returns them under `matches`. Fixed by reading `matches` with a fallback to `memories`. Also guarded `m.salience.toFixed(3)`, which throws when a match comes back without a `salience` field — that would have been the next crash.

### 2. Flag names leaked into positional text

Both `add` and `query` parsed text with:

```js
argv.slice(1, argv.indexOf('--')).join(' ')
```

This looks for a bare `--`, which no documented invocation passes. `indexOf` returns `-1`, so the slice becomes `slice(1, -1)`: it drops the final argument and joins the flag **name** into the text.

```
$ opm add "note" --tags x     # stored: "note --tags"
$ opm query "text" --limit 2  # searched for: "text --limit"
```

The `add` case silently corrupted stored memory content. The `query` case was masked by bug 1, and would have silently degraded results once that was fixed. Replaced with a helper that takes positional args up to the first `--flag`.

### 3. `opm add --help` stored a memory containing `--help`

`--help` was only recognised in the command position, so it fell through to `add` and was treated as content. Any `--help`/`-h` token now prints help before dispatch. The match is on exact tokens, so quoted text mentioning `--help` is unaffected.

## Test plan

Verified against a live server:

- `opm query "text"` returns results (previously crashed 100% of the time)
- `opm query "text" --limit 2` respects the limit and no longer pollutes the query text
- `opm add "text" --tags a,b` stores clean content with tags applied correctly
- `opm add --help` prints help instead of storing
- `opm query` / `opm add` with no arguments still error cleanly

## Notes

No dependency or API changes; `bin/opm.js` only. Behaviour for correct existing invocations is unchanged, except that text no longer has flag names appended.
